### PR TITLE
add GOROOT env

### DIFF
--- a/cells/tullia/devshell.nix
+++ b/cells/tullia/devshell.nix
@@ -9,5 +9,6 @@
         ++ [
           inputs.std.std.cli.default
         ];
+      GOROOT = "${pkgs.go}/share/go";
     };
 }


### PR DESCRIPTION
Prevent devshell's go version doesn't match the host.

fixes:
```
compile: version go.xxx does not match go tool version "go1.17.9"
```