### PR TITLE
Allow go-getter subdirectories in repo string.

### DIFF
--- a/lib/github.cue
+++ b/lib/github.cue
@@ -16,7 +16,7 @@ import "strings"
 			}
 		}.result
 
-		#repo:           =~"^[^/]+/[^/]+$"
+		#repo:           =~"^[^/]+/[^/]+(//[^/]+)?$"
 		#target?:        string
 		#target_default: bool | *true
 


### PR DESCRIPTION
I want to expand the regex for repo strings in our github.cue template.
In the current state subdirectories are ignored, so I suggest this change.

In this image the slash is escaped but its shows that the new regex works.
![image](https://user-images.githubusercontent.com/42609861/190364264-ddaf4410-ef49-4a79-9d24-8ab147dedb85.png)

The reason behind is, that the [Tullia-example ](https://github.com/input-output-hk/tullia-example) repository uses a flake.nix in a subdirectory and at the moment it is not possible to add a actions.nix to Cicero with "github.com/input-output-hk/tullia-exampe//rust"  as repo string.