### PR TITLE
fix: replace hydra.iokh.io with cache.iog.io

### DIFF
--- a/nix/preset/nix.nix
+++ b/nix/preset/nix.nix
@@ -13,7 +13,6 @@
       substituters = {
         "https://cache.nixos.org" = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
         "https://cache.iog.io" = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=";
-        "https://cache.ci.iog.io" = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=";
       };
     in
       lib.mkBefore [

--- a/nix/preset/nix.nix
+++ b/nix/preset/nix.nix
@@ -12,7 +12,7 @@
     oci.copyToRoot = let
       substituters = {
         "https://cache.nixos.org" = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
-        "https://hydra.iohk.io" = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=";
+        "https://cache.iog.io" = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=";
         "https://cache.ci.iog.io" = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=";
       };
     in


### PR DESCRIPTION
The nix preset was setting https://hydra.iohk.io as a substituter. This binary cache was decommissioned on Dec. 1, 2022. This PR updates it to refer to https://cache.iog.io instead.