### PR TITLE
Bumup std

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -365,11 +365,11 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1673226500,
-        "narHash": "sha256-e8CbGpxxfKiO8IFUlNxFkbIXepOPurZBQuHeH6/yHi4=",
+        "lastModified": 1674526466,
+        "narHash": "sha256-tMTaS0bqLx6VJ+K+ZT6xqsXNpzvSXJTmogkraBGzymg=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "7b19892d7633d06877f7f30ba48809520a59d280",
+        "rev": "516387e3d8d059b50e742a2ff1909ed3c8f82826",
         "type": "github"
       },
       "original": {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -795,7 +795,7 @@
                     # if you got the permission error like  Couldn't write '5' bytes to file
                     # '/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service//NSJAIL.13077/cgroup.procs'
                     # run the following command
-                    # sudo chown "$USER":users /sys/fs/cgroup/user.slice/user-1000.slice/*
+                    # sudo chown "$USER":users /sys/fs/cgroup/user.slice/user-1000.slice/cgroup.procs
 
                     cgroupV2Mount="/sys/fs/cgroup/user.slice/user-$uid.slice/user@$uid.service"
                     if [ ! -d "$cgroupV2Mount" ]; then


### PR DESCRIPTION
can be sure this PR works well with the following actions.
Actions test:

```
std //tullia/task/tidy:nsjail
warning: Git tree '/home/guangtao/ghq/github.com/input-output-hk/tullia' is dirty
+ exec tullia run tidy
+ go mod tidy -v
go: downloading github.com/alexflint/go-arg v1.4.3
go: downloading github.com/goombaio/dag v0.0.0-20181006234417-a8874b1f72ff
go: downloading github.com/charmbracelet/bubbletea v0.20.0
go: downloading github.com/pkg/errors v0.9.1
```


```
std //tullia/task/tidy:copyToPodman
Copy to podman image localhost/tidy:rrv60y5r75anafqyq6bj1qg62g9s823c
Getting image source signatures
Copying blob 21b600c1f96d done  
Copying blob f85221721721 done  
Copying blob fa7c3bd91145 done  
Copying blob 3b56451a040b done  
^CERRO[0001] signal: interrupt                     
```