### PR TITLE
hotfix: missing double quote

### DIFF
--- a/cells/tullia/apps.nix
+++ b/cells/tullia/apps.nix
@@ -165,7 +165,7 @@ in {
           )
         fi
 
-        jq --raw-{input,output} --slurp ''${nullInput:-} \
+        jq --raw-{input,output} --slurp "''${nullInput:-}" \
           --argjson local "''${local:-true}" \
           --argjson remote "''${remote:-true}" \
           --argjson stdin "''${stdin:-false}" \


### PR DESCRIPTION
@dermetfan 
- reproduce command:
```
tullia run ci --runtime unwrapped
```
Output:
```
> In /nix/store/gjsr5hnjdsf0fkzab74d3jc0dxhab6gv-nix-systems/bin/nix-systems line 62:                                    
> jq --raw-{input,output} --slurp ${nullInput:-} \                                                                       
>                                 ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.     
>                                                                                                                        
> Did you mean:                                                                                                          
> jq --raw-{input,output} --slurp "${nullInput:-}" \          
```

